### PR TITLE
修改错误的 Timestamp

### DIFF
--- a/coolq/bot.go
+++ b/coolq/bot.go
@@ -514,7 +514,7 @@ func (bot *CQBot) formatGroupMessage(m *message.GroupMessage) MSG {
 			"user_id": m.Sender.Uin,
 		},
 		"sub_type": "normal",
-		"time":     time.Now().Unix(),
+		"time":     m.Time,
 		"user_id":  m.Sender.Uin,
 	}
 	if m.Sender.IsAnonymous() {


### PR DESCRIPTION
在用 `get_group_msg_history` 的时候发现的

每次转换讯息都只用当前时间, 这样会严重扰乱其它程序对信息的 `Timestamp` 进行储存的依赖

gocq 主程序却把正常的 Timestamp 储存进 leveldb 里面, 让人感觉到有一点偏心

以上是废话, 简单一句:

解决程序错误返回群信息的 `Timestamp`